### PR TITLE
Fix normal build permissions and env exec check

### DIFF
--- a/java8/s2i/bin/assemble
+++ b/java8/s2i/bin/assemble
@@ -28,16 +28,13 @@ cp -Rf /tmp/src/. ./
 if [ -f "./sbt" ]; then
   echo "---> Building application from source..."
   ./sbt -ivy /opt/app-root/src/.ivy2 -sbt-dir /opt/app-root/src/.sbt -sbt-boot /opt/app-root/src/.sbt/boot stage
-  if [ $(find target/universal/stage/bin -type f -executable | wc -l) -eq 1 ]; then
-    chmod a+x $(find target/universal/stage/bin -type f -executable)
-  else
-    echo "Could not detect proper start command in $(find target/universal/stage/bin)"
-  fi
+  echo "---> Fixing permission for build..."
+  chmod a+x $(find target/universal/stage/bin -type f -executable)
 else
   echo "---> Fixing permission for binary build..."
-  if [ -f "./bin" ]; then
+  if [ -d "./bin" ]; then
     chmod a+x $(find bin -type f -executable)
-  elif [ -f "target/universal/stage/bin" ]; then
+  elif [ -d "./target/universal/stage/bin" ]; then
     chmod a+x $(find target/universal/stage/bin -type f -executable)
   else
    echo "---> No binary build permissions to fix."

--- a/java8/s2i/bin/run
+++ b/java8/s2i/bin/run
@@ -22,7 +22,7 @@ if [ "$DEV_MODE" == true ]; then
   exec ./sbt -ivy /opt/app-root/src/.ivy2 -sbt-dir /opt/app-root/src/.sbt -sbt-boot /opt/app-root/src/.sbt/boot -jvm-debug ${DEBUG_PORT} run
 else
   echo "Launching via script"
-  if [ -z "$SBT_APP_BINARY_PATH" ]; then
+  if [ -v SBT_APP_BINARY_PATH ]; then
     exec $SBT_APP_BINARY_PATH
   elif [ $(find target/universal/stage/bin -type f -executable | wc -l) -eq 1 ]; then
     exec $(find target/universal/stage/bin -type f -executable)


### PR DESCRIPTION
- Always add exec permissions for non-binary builds
- check for directory instead of file when fixing binary build permissions
- Check to see if var is set when running from env var path